### PR TITLE
Improve PDF search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,50 @@
-cd your-project-folder
-git init
-git add .
-git commit -m "Initial commit"
-git branch -M main
-git remote add origin https://github.com/your-username/your-repo.git
-git push -u origin main
+# User Management System
+
+This is a minimal user management API built with Node.js using only built-in modules. It supports:
+
+- User registration and login with password hashing.
+- JWT-like token generation for session management.
+- Admin endpoints to list users, grant or revoke access, and view user logs.
+- Access status tracking (Active, Expired, Revoked) based on expiration time or manual revocation.
+
+## Running
+
+```bash
+node server.js
+```
+
+The server listens on port `3000` and stores data in `users.json` in the project directory.
+
+## API Endpoints
+
+- `POST /register` – `{ name, email, password }`
+- `POST /login` – `{ email, password }`
+- `GET /me` – requires `Authorization` header with token
+- `GET /admin/users` – admin only
+- `POST /admin/grant/:id` – admin only, body `{ days }`
+- `POST /admin/revoke/:id` – admin only
+- `GET /admin/logs/:id` – admin only
+
+Tokens are returned on login and must be sent in the `Authorization` header.
+
+## PDF Upload Service
+
+A simple Flask app `pdf_extract.py` accepts PDF uploads and returns the text of each page as JSON. Install dependencies with `pip install flask pdfplumber` and run:
+
+```bash
+python pdf_extract.py
+```
+
+Send a `POST /upload` request with form-data key `pdf` to receive a list of pages and their text.
+
+## PDF QA Helper
+
+Use `pdf_qa.py` to search a PDF for the answer to a question:
+
+```bash
+python pdf_qa.py document.pdf "What is the meaning of life?"
+```
+
+You will be prompted for your question, and if Pillow is available the matching page image will open in a viewer.
+The script prints a snippet from the page with the most keyword matches and shows its page number.
+

--- a/pdf_extract.py
+++ b/pdf_extract.py
@@ -1,0 +1,19 @@
+from flask import Flask, request, jsonify
+import pdfplumber
+
+app = Flask(__name__)
+
+@app.route('/upload', methods=['POST'])
+def upload_pdf():
+    if 'pdf' not in request.files:
+        return jsonify({'error': 'no file'}), 400
+    file = request.files['pdf']
+    results = []
+    with pdfplumber.open(file.stream) as pdf:
+        for i, page in enumerate(pdf.pages, start=1):
+            text = page.extract_text() or ''
+            results.append({'page': i, 'text': text})
+    return jsonify({'pages': results})
+
+if __name__ == '__main__':
+    app.run(port=5000)

--- a/pdf_qa.py
+++ b/pdf_qa.py
@@ -1,0 +1,61 @@
+import sys
+import pdfplumber
+from PIL import Image
+import tempfile
+
+
+def extract_pages(pdf_path):
+    pages = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for i, page in enumerate(pdf.pages, start=1):
+            text = page.extract_text() or ''
+            pages.append({'page': i, 'text': text})
+    return pages
+
+
+def best_match(pages, question):
+    keywords = [w.lower() for w in question.strip('?').split() if w]
+    best = None
+    best_score = 0
+    for p in pages:
+        text_lower = p['text'].lower()
+        score = sum(text_lower.count(k) for k in keywords)
+        if score > best_score:
+            best = p
+            best_score = score
+    if best and best_score > 0:
+        snippet = best['text'][:300]
+        return {'page': best['page'], 'text': snippet}
+    return None
+
+
+def show_page_image(pdf_path, page_num):
+    try:
+        with pdfplumber.open(pdf_path) as pdf:
+            page = pdf.pages[page_num - 1]
+            img = page.to_image(resolution=150)
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+                img.save(tmp.name, format='PNG')
+                Image.open(tmp.name).show()
+    except Exception as e:
+        print('Could not display page image:', e)
+
+
+def main():
+    if len(sys.argv) < 2:
+        pdf_path = input('Enter path to PDF file: ')
+    else:
+        pdf_path = sys.argv[1]
+    question = input('Enter your question: ')
+    pages = extract_pages(pdf_path)
+    result = best_match(pages, question)
+    if result:
+        print(f"Answer likely on page {result['page']}:")
+        print(result['text'])
+        show_page_image(pdf_path, result['page'])
+    else:
+        print('Answer not found')
+
+
+if __name__ == '__main__':
+    main()

--- a/question.js
+++ b/question.js
@@ -1,0 +1,22 @@
+const readline = require('readline');
+
+function getUserQuestion() {
+  return new Promise(resolve => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+    rl.question('Enter your question: ', q => {
+      rl.close();
+      resolve(q);
+    });
+  });
+}
+
+async function main() {
+  const userQuestion = await getUserQuestion();
+  console.log('Question stored:', userQuestion);
+}
+
+main();
+

--- a/search_pdf.py
+++ b/search_pdf.py
@@ -1,0 +1,55 @@
+import sys
+import pdfplumber
+
+
+def extract_pages(pdf_path):
+    pages = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for i, page in enumerate(pdf.pages, start=1):
+            text = page.extract_text() or ''
+            pages.append({'page': i, 'text': text})
+    return pages
+
+
+def find_answer(pages, question):
+    keywords = [w.lower() for w in question.strip('?').split() if w]
+    for p in pages:
+        text_lower = p['text'].lower()
+        if all(k in text_lower for k in keywords):
+            return p
+    return None
+
+
+def best_match(pages, question):
+    """Return the page with the most keyword matches."""
+    keywords = [w.lower() for w in question.strip('?').split() if w]
+    best = None
+    best_score = 0
+    for p in pages:
+        text_lower = p['text'].lower()
+        score = sum(text_lower.count(k) for k in keywords)
+        if score > best_score:
+            best = p
+            best_score = score
+    if not best or best_score == 0:
+        return None
+    snippet = best['text'][:300]
+    return {'page': best['page'], 'text': snippet}
+
+
+def main():
+    if len(sys.argv) < 3:
+        print('Usage: python search_pdf.py <pdf_path> "<question>"')
+        return
+    pdf_path = sys.argv[1]
+    question = sys.argv[2]
+    pages = extract_pages(pdf_path)
+    result = best_match(pages, question)
+    if result:
+        print(f"Page {result['page']}:\n{result['text']}")
+    else:
+        print('Answer not found')
+
+
+if __name__ == '__main__':
+    main()

--- a/server.js
+++ b/server.js
@@ -1,0 +1,143 @@
+const http = require('http');
+const crypto = require('crypto');
+const fs = require('fs');
+
+const DATA_FILE = 'users.json';
+const SECRET = 'mysecret';
+
+function loadUsers() {
+  try {
+    return JSON.parse(fs.readFileSync(DATA_FILE));
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveUsers(users) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(users, null, 2));
+}
+
+function hashPassword(password, salt) {
+  const hash = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
+  return { salt, hash };
+}
+
+function verifyPassword(password, user) {
+  const hashed = crypto.pbkdf2Sync(password, user.salt, 1000, 64, 'sha512').toString('hex');
+  return hashed === user.hash;
+}
+
+function generateToken(payload) {
+  const data = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const sig = crypto.createHmac('sha256', SECRET).update(data).digest('base64url');
+  return data + '.' + sig;
+}
+
+function verifyToken(token) {
+  const [data, sig] = token.split('.');
+  if (!data || !sig) return null;
+  const check = crypto.createHmac('sha256', SECRET).update(data).digest('base64url');
+  if (check !== sig) return null;
+  return JSON.parse(Buffer.from(data, 'base64url').toString());
+}
+
+function send(res, status, obj) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+}
+
+function logActivity(user, action) {
+  user.logs = user.logs || [];
+  user.logs.push({ action, time: Date.now() });
+}
+
+function getStatus(user) {
+  if (user.revoked) return 'Revoked';
+  if (user.accessExpires && Date.now() > user.accessExpires) return 'Expired';
+  return 'Active';
+}
+
+const server = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', chunk => body += chunk);
+  req.on('end', () => {
+    const users = loadUsers();
+    const url = new URL(req.url, 'http://localhost');
+    // registration
+    if (req.method === 'POST' && url.pathname === '/register') {
+      const { name, email, password } = JSON.parse(body || '{}');
+      if (!email || !password) return send(res, 400, { error: 'Invalid' });
+      if (users.find(u => u.email === email)) return send(res, 400, { error: 'Exists' });
+      const id = crypto.randomUUID();
+      const { salt, hash } = hashPassword(password, crypto.randomBytes(16).toString('hex'));
+      const user = { id, name, email, salt, hash, role: 'user', revoked: false };
+      logActivity(user, 'register');
+      users.push(user);
+      saveUsers(users);
+      send(res, 201, { message: 'registered' });
+    // login
+    } else if (req.method === 'POST' && url.pathname === '/login') {
+      const { email, password } = JSON.parse(body || '{}');
+      const user = users.find(u => u.email === email);
+      if (!user || !verifyPassword(password, user)) return send(res, 401, { error: 'Unauthorized' });
+      logActivity(user, 'login');
+      saveUsers(users);
+      const token = generateToken({ id: user.id, role: user.role });
+      send(res, 200, { token });
+    // get current user data
+    } else if (req.method === 'GET' && url.pathname === '/me') {
+      const token = req.headers['authorization'];
+      const payload = token && verifyToken(token);
+      if (!payload) return send(res, 401, { error: 'Unauthorized' });
+      const user = users.find(u => u.id === payload.id);
+      if (!user) return send(res, 404, { error: 'Not found' });
+      send(res, 200, { id: user.id, name: user.name, email: user.email, status: getStatus(user) });
+    // admin list users
+    } else if (req.method === 'GET' && url.pathname === '/admin/users') {
+      const token = req.headers['authorization'];
+      const payload = token && verifyToken(token);
+      if (!payload || payload.role !== 'admin') return send(res, 401, { error: 'Unauthorized' });
+      const result = users.map(u => ({ id: u.id, email: u.email, role: u.role, status: getStatus(u) }));
+      send(res, 200, result);
+    // grant access
+    } else if (req.method === 'POST' && url.pathname.startsWith('/admin/grant/')) {
+      const token = req.headers['authorization'];
+      const payload = token && verifyToken(token);
+      if (!payload || payload.role !== 'admin') return send(res, 401, { error: 'Unauthorized' });
+      const id = url.pathname.split('/').pop();
+      const user = users.find(u => u.id === id);
+      if (!user) return send(res, 404, { error: 'Not found' });
+      const { days } = JSON.parse(body || '{}');
+      user.accessExpires = Date.now() + (days || 7) * 86400000;
+      user.revoked = false;
+      logActivity(user, `grant ${days}`);
+      saveUsers(users);
+      send(res, 200, { message: 'granted', until: user.accessExpires });
+    // revoke access
+    } else if (req.method === 'POST' && url.pathname.startsWith('/admin/revoke/')) {
+      const token = req.headers['authorization'];
+      const payload = token && verifyToken(token);
+      if (!payload || payload.role !== 'admin') return send(res, 401, { error: 'Unauthorized' });
+      const id = url.pathname.split('/').pop();
+      const user = users.find(u => u.id === id);
+      if (!user) return send(res, 404, { error: 'Not found' });
+      user.revoked = true;
+      logActivity(user, 'revoke');
+      saveUsers(users);
+      send(res, 200, { message: 'revoked' });
+    // user logs
+    } else if (req.method === 'GET' && url.pathname.startsWith('/admin/logs/')) {
+      const token = req.headers['authorization'];
+      const payload = token && verifyToken(token);
+      if (!payload || payload.role !== 'admin') return send(res, 401, { error: 'Unauthorized' });
+      const id = url.pathname.split('/').pop();
+      const user = users.find(u => u.id === id);
+      if (!user) return send(res, 404, { error: 'Not found' });
+      send(res, 200, { logs: user.logs || [] });
+    } else {
+      send(res, 404, { error: 'Not found' });
+    }
+  });
+});
+
+server.listen(3000, () => console.log('Server running on 3000'));

--- a/users.json
+++ b/users.json
@@ -1,0 +1,3 @@
+[
+  {"id":"1","name":"Admin","email":"admin@example.com","salt":"eafef7bcbf946ea8a679338d6bff7d46","hash":"cc8475ecedbc93e39822a24e77a77a219967bcda18d7f40deb2ce3ff166a6ba36ba0a9546b83596c7d7eb89dc18de6614e2f352ea1ad185a1cc3eddfad449dc3","role":"admin","revoked":false}
+]


### PR DESCRIPTION
## Summary
- tweak PDF search helper to score keyword matches
- update README with updated description of the search helper
- add unified PDF QA script to upload a PDF, ask a question, and show answer with page image

## Testing
- `node server.js > /tmp/server.log &` *(server starts on port 3000)*
- `python3 pdf_extract.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python3 search_pdf.py sample.pdf "test"` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*
- `python3 pdf_qa.py sample.pdf` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*


------
https://chatgpt.com/codex/tasks/task_e_6846bf915e908325bab3901e79e7e4f0