### PR TITLE
Add EduNest React frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ The server listens on port `3000` and stores data in `users.json` in the project
 - `GET /admin/logs/:id` – admin only
 
 Tokens are returned on login and must be sent in the `Authorization` header.
+
+## EduNest Frontend
+
+A demo React + Tailwind CSS interface using Firebase authentication. To start the development server:
+
+```bash
+cd edunest
+npm install
+npm run dev
+```
+
+Demo logins:
+- Admin: `admin@edunest.com / admin123`
+- Student: `student@edunest.com / student123`

--- a/edunest/.gitignore
+++ b/edunest/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.dist
+.env

--- a/edunest/index.html
+++ b/edunest/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EduNest</title>
+  </head>
+  <body class="bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/edunest/package.json
+++ b/edunest/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "edunest",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1",
+    "firebase": "^9.22.2",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.5.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/edunest/postcss.config.cjs
+++ b/edunest/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/edunest/src/App.jsx
+++ b/edunest/src/App.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from 'react-router-dom';
+import Dashboard from './pages/Dashboard';
+import Login from './pages/Login';
+import AdminPanel from './pages/AdminPanel';
+import PrivateRoute from './components/PrivateRoute';
+import AdminRoute from './components/AdminRoute';
+
+export default function App() {
+  return (
+    <Router>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/admin/*"
+          element={
+            <AdminRoute>
+              <AdminPanel />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="/*"
+          element={
+            <PrivateRoute>
+              <Dashboard />
+            </PrivateRoute>
+          }
+        />
+      </Routes>
+    </Router>
+  );
+}

--- a/edunest/src/components/AdminRoute.jsx
+++ b/edunest/src/components/AdminRoute.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export default function AdminRoute({ children }) {
+  const { user, loading } = useAuth();
+  if (loading) return <div>Loading...</div>;
+  return user && user.role === 'admin' ? children : <Navigate to="/login" />;
+}

--- a/edunest/src/components/CourseCard.jsx
+++ b/edunest/src/components/CourseCard.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function CourseCard({ course }) {
+  return (
+    <div className="border rounded p-4 shadow-sm bg-white dark:bg-gray-800">
+      <h3 className="text-lg font-semibold">{course.title}</h3>
+      <p className="text-sm text-gray-500">Instructor: {course.instructor}</p>
+      <div className="mt-2 space-x-1">
+        {course.tags.map(tag => (
+          <span
+            key={tag}
+            className="inline-block bg-gray-200 dark:bg-gray-700 text-xs px-2 py-1 rounded"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/edunest/src/components/PrivateRoute.jsx
+++ b/edunest/src/components/PrivateRoute.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export default function PrivateRoute({ children }) {
+  const { user, loading } = useAuth();
+  if (loading) return <div>Loading...</div>;
+  return user ? children : <Navigate to="/login" />;
+}

--- a/edunest/src/components/ProgressBar.jsx
+++ b/edunest/src/components/ProgressBar.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function ProgressBar({ value = 0 }) {
+  return (
+    <div className="w-full bg-gray-200 rounded-full h-4 dark:bg-gray-700">
+      <div
+        className="bg-blue-600 h-4 rounded-full"
+        style={{ width: `${value}%` }}
+      ></div>
+    </div>
+  );
+}

--- a/edunest/src/components/Sidebar.jsx
+++ b/edunest/src/components/Sidebar.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+export default function Sidebar() {
+  const links = [
+    { to: 'home', label: 'Home' },
+    { to: 'explore', label: 'Explore Courses' },
+    { to: 'my-courses', label: 'My Courses' },
+    { to: 'fees', label: 'Fees' },
+    { to: 'alerts', label: 'Alerts' },
+    { to: 'messages', label: 'Messages' },
+    { to: 'calendar', label: 'Calendar' },
+    { to: 'settings', label: 'Settings' },
+  ];
+  return (
+    <aside className="w-60 bg-white dark:bg-gray-900 h-screen p-4 shadow-md">
+      <h2 className="text-xl font-bold mb-4">EduNest</h2>
+      <nav className="flex flex-col space-y-2">
+        {links.map(link => (
+          <NavLink
+            key={link.to}
+            to={link.to}
+            className={({ isActive }) =>
+              `py-2 px-3 rounded hover:bg-gray-200 dark:hover:bg-gray-700 ${
+                isActive ? 'bg-gray-200 dark:bg-gray-700 font-semibold' : ''
+              }`
+            }
+          >
+            {link.label}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/edunest/src/components/ThemeToggle.jsx
+++ b/edunest/src/components/ThemeToggle.jsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    if (dark) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [dark]);
+
+  return (
+    <button
+      onClick={() => setDark(!dark)}
+      className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700"
+    >
+      {dark ? 'Light' : 'Dark'}
+    </button>
+  );
+}

--- a/edunest/src/context/AuthContext.jsx
+++ b/edunest/src/context/AuthContext.jsx
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  onAuthStateChanged,
+} from 'firebase/auth';
+import { initializeApp } from 'firebase/app';
+import { firebaseConfig } from '../utils/firebase';
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+
+const roles = {
+  'admin@edunest.com': 'admin',
+  'student@edunest.com': 'student',
+};
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, u => {
+      if (u) {
+        const role = roles[u.email] || 'student';
+        setUser({ email: u.email, uid: u.uid, role });
+      } else {
+        setUser(null);
+      }
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  const login = (email, password) => signInWithEmailAndPassword(auth, email, password);
+  const register = (email, password) => createUserWithEmailAndPassword(auth, email, password);
+  const logout = () => signOut(auth);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/edunest/src/data/assignments.js
+++ b/edunest/src/data/assignments.js
@@ -1,0 +1,4 @@
+export default [
+  { id: 1, title: 'Math Homework 2', due: '2025-07-15' },
+  { id: 2, title: 'Essay Draft', due: '2025-07-20' },
+];

--- a/edunest/src/data/courses.js
+++ b/edunest/src/data/courses.js
@@ -1,0 +1,5 @@
+export default [
+  { id: 1, title: 'Intro to Math', instructor: 'Dr. Smith', tags: ['math'], category: 'STEM' },
+  { id: 2, title: 'History 101', instructor: 'Prof. Jones', tags: ['history'], category: 'Humanities' },
+  { id: 3, title: 'Physics Basics', instructor: 'Dr. Brown', tags: ['physics'], category: 'STEM' },
+];

--- a/edunest/src/data/fees.js
+++ b/edunest/src/data/fees.js
@@ -1,0 +1,4 @@
+export default {
+  paid: 1200,
+  pending: 300,
+};

--- a/edunest/src/index.css
+++ b/edunest/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html.dark {
+  @apply bg-gray-800 text-gray-100;
+}

--- a/edunest/src/main.jsx
+++ b/edunest/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+import { AuthProvider } from './context/AuthContext';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </React.StrictMode>
+);

--- a/edunest/src/pages/AdminPanel.jsx
+++ b/edunest/src/pages/AdminPanel.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import courses from '../data/courses';
+
+export default function AdminPanel() {
+  const [list, setList] = useState(courses);
+  const [title, setTitle] = useState('');
+
+  const addCourse = () => {
+    if (!title) return;
+    setList([...list, { id: list.length + 1, title, instructor: 'Admin', tags: [] }]);
+    setTitle('');
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Admin Panel</h1>
+      <div className="mb-4">
+        <input
+          className="border px-3 py-2 rounded mr-2"
+          placeholder="New course title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <button className="bg-blue-600 text-white px-3 py-2 rounded" onClick={addCourse}>Add</button>
+      </div>
+      <h2 className="text-xl font-semibold mb-2">Courses</h2>
+      <ul className="list-disc list-inside">
+        {list.map(c => (
+          <li key={c.id}>{c.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/edunest/src/pages/Alerts.jsx
+++ b/edunest/src/pages/Alerts.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+const initialAlerts = [
+  { id: 1, text: 'Assignment 1 due tomorrow', read: false },
+  { id: 2, text: 'New course available', read: true },
+];
+
+export default function Alerts() {
+  const [alerts, setAlerts] = useState(initialAlerts);
+  const toggle = id => {
+    setAlerts(a => a.map(al => (al.id === id ? { ...al, read: !al.read } : al)));
+  };
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">Alerts</h1>
+      <ul>
+        {alerts.map(al => (
+          <li key={al.id} className="flex items-center justify-between mb-2">
+            <span className={al.read ? 'text-gray-400' : ''}>{al.text}</span>
+            <button
+              className="text-sm text-blue-600"
+              onClick={() => toggle(al.id)}
+            >
+              {al.read ? 'Mark unread' : 'Mark read'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/edunest/src/pages/Calendar.jsx
+++ b/edunest/src/pages/Calendar.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function Calendar() {
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const schedule = [
+    { day: 'Mon', subject: 'Math' },
+    { day: 'Wed', subject: 'Science' },
+    { day: 'Fri', subject: 'History' },
+  ];
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">Calendar</h1>
+      <ul>
+        {days.map(d => (
+          <li key={d} className="mb-2">
+            <span className="font-semibold mr-2">{d}:</span>
+            {schedule.find(s => s.day === d)?.subject || '—'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/edunest/src/pages/Dashboard.jsx
+++ b/edunest/src/pages/Dashboard.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { NavLink, Outlet, Routes, Route, Navigate } from 'react-router-dom';
+import Sidebar from '../components/Sidebar';
+import ThemeToggle from '../components/ThemeToggle';
+import Home from './Home';
+import ExploreCourses from './ExploreCourses';
+import MyCourses from './MyCourses';
+import Fees from './Fees';
+import Alerts from './Alerts';
+import Messages from './Messages';
+import Calendar from './Calendar';
+import Settings from './Settings';
+
+export default function Dashboard() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1 p-6 bg-gray-50 dark:bg-gray-900">
+        <div className="flex justify-end mb-4">
+          <ThemeToggle />
+        </div>
+        <Routes>
+          <Route path="home" element={<Home />} />
+          <Route path="explore" element={<ExploreCourses />} />
+          <Route path="my-courses" element={<MyCourses />} />
+          <Route path="fees" element={<Fees />} />
+          <Route path="alerts" element={<Alerts />} />
+          <Route path="messages" element={<Messages />} />
+          <Route path="calendar" element={<Calendar />} />
+          <Route path="settings" element={<Settings />} />
+          <Route path="" element={<Navigate to="home" />} />
+        </Routes>
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/edunest/src/pages/ExploreCourses.jsx
+++ b/edunest/src/pages/ExploreCourses.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import courses from '../data/courses';
+import CourseCard from '../components/CourseCard';
+
+export default function ExploreCourses() {
+  const [search, setSearch] = useState('');
+  const filtered = courses.filter(c =>
+    c.title.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div>
+      <div className="mb-4">
+        <input
+          className="border px-3 py-2 rounded w-full"
+          placeholder="Search courses"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+      <div className="grid md:grid-cols-2 gap-4">
+        {filtered.map(course => (
+          <CourseCard key={course.id} course={course} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/edunest/src/pages/Fees.jsx
+++ b/edunest/src/pages/Fees.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement } from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement);
+
+const data = {
+  labels: ['Paid', 'Pending'],
+  datasets: [
+    {
+      label: 'Fees',
+      data: [1200, 300],
+      backgroundColor: ['#4ade80', '#f87171'],
+    },
+  ],
+};
+
+export default function Fees() {
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">Fees Overview</h1>
+      <Bar data={data} />
+    </div>
+  );
+}

--- a/edunest/src/pages/Home.jsx
+++ b/edunest/src/pages/Home.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ProgressBar from '../components/ProgressBar';
+import assignments from '../data/assignments';
+
+export default function Home() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Welcome back!</h1>
+      <p className="mb-2">Your progress:</p>
+      <ProgressBar value={70} />
+      <h2 className="text-xl font-semibold mt-6 mb-2">Upcoming Assignments</h2>
+      <ul className="list-disc list-inside">
+        {assignments.map(a => (
+          <li key={a.id}>{a.title} - due {a.due}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/edunest/src/pages/Login.jsx
+++ b/edunest/src/pages/Login.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export default function Login() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      navigate('/');
+    } catch (err) {
+      setError('Failed to login');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-6 rounded shadow w-80 space-y-4">
+        <h1 className="text-xl font-bold text-center">EduNest Login</h1>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <input
+          className="w-full px-3 py-2 border rounded"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          className="w-full px-3 py-2 border rounded"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="w-full bg-blue-600 text-white py-2 rounded" type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/edunest/src/pages/Messages.jsx
+++ b/edunest/src/pages/Messages.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const messages = [
+  { id: 1, sender: 'Instructor', preview: 'Please submit...', time: '1h ago', unread: true },
+  { id: 2, sender: 'Admin', preview: 'Welcome to EduNest!', time: '1d ago', unread: false },
+];
+
+export default function Messages() {
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">Messages</h1>
+      <ul>
+        {messages.map(m => (
+          <li key={m.id} className="border-b py-2">
+            <div className="flex justify-between">
+              <span className="font-semibold">{m.sender}</span>
+              {m.unread && <span className="text-xs bg-blue-600 text-white rounded px-2">New</span>}
+            </div>
+            <p className="text-sm text-gray-500">{m.preview}</p>
+            <span className="text-xs text-gray-400">{m.time}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/edunest/src/pages/MyCourses.jsx
+++ b/edunest/src/pages/MyCourses.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import courses from '../data/courses';
+
+export default function MyCourses() {
+  const enrolled = courses.slice(0, 2);
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">My Courses</h1>
+      <ul className="list-disc list-inside">
+        {enrolled.map(c => (
+          <li key={c.id}>{c.title} - 50% complete</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/edunest/src/pages/Settings.jsx
+++ b/edunest/src/pages/Settings.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useAuth } from '../context/AuthContext';
+
+export default function Settings() {
+  const { logout } = useAuth();
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-4">Settings</h1>
+      <button
+        onClick={logout}
+        className="bg-red-600 text-white px-3 py-2 rounded"
+      >
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/edunest/src/utils/firebase.js
+++ b/edunest/src/utils/firebase.js
@@ -1,0 +1,8 @@
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_BUCKET",
+  messagingSenderId: "YOUR_SENDER_ID",
+  appId: "YOUR_APP_ID",
+};

--- a/edunest/tailwind.config.cjs
+++ b/edunest/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/edunest/vite.config.js
+++ b/edunest/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add EduNest React + Tailwind frontend inside `/edunest`
- implement basic routing, context, and pages with dummy data
- update README with instructions and demo logins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cfff70a7c8325ada0e82e0f7d2bab